### PR TITLE
readme: center the og, drop the extra heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# jass.gg
+<p align="center">
+  <img src="public/og.png" alt="jass.gg" width="420" />
+</p>
 
-![jass.gg](public/og.png)
-
-my place on the web.
+<p align="center">my place on the web.</p>


### PR DESCRIPTION
## Summary
- README is the og and the one-liner, centered
- No extra heading

## Test plan
- [ ] GitHub README looks clean